### PR TITLE
Fix Gitpod link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Quickstart
 
-Clone this repo or [open in Gitpod](https://gitpod.io/#https://github.com/total-typescript/beginners-typescript).
+Clone this repo or [open in Gitpod](https://gitpod.io/#https://github.com/total-typescript/type-transformations-tutorial).
 
 ```sh
 # Installs all dependenciesG


### PR DESCRIPTION
The link leads to the `beginners-typescript` Gitpod workspace